### PR TITLE
Update website link for 2FA directory

### DIFF
--- a/5_Privacy_Respecting_Software.md
+++ b/5_Privacy_Respecting_Software.md
@@ -142,7 +142,7 @@ If you are using a deprecated PM, you should migrate to something actively maint
 **[Raivo OTP](https://github.com/raivo-otp/ios-application)** (iOS) | A native, lightweight and secure one-time-password (OTP) client built for iOS; Raivo OTP! - built by @tijme
 **[WinAuth](https://winauth.github.io/winauth)** (Windows) | Portable, encrypted desktop authenticator app for Microsoft Windows. With useful features, like hotkeys and some additional security tools, WinAuth is a great companion authenticator for desktop power-users. It's open source and well-established (since mid-2010)
 
-*Check which websites support multi-factor authentication: [twofactorauth.org](https://twofactorauth.org)*
+*Check which websites support multi-factor authentication: [2fa.directory](https://2fa.directory/)*
 
 #### Notable Mentions
 


### PR DESCRIPTION
twofactorauth.org now redirects to https://brainstation.io/cybersecurity/two-factor-auth which does not display websites that have 2FA support. I believe the directory of websites with 2FA support is now hosted on https://2fa.directory/.

````
🙌 Thanks for contributing 🙌

Jut briefly describe what you've added/ modified, and why, then delete these guidelines 🙂

If you are adding to the software list, ensure that:
- It is open source or results of an independent audited have been published
- You have used the application or service personally, and would recommend
- You've done a quick search to ensure there are no major or current vulnerabilities
- You've include a link to  project page for download or use, and if applicable the repository
- If you are adding your own project or your companies product, mention this in the PR description
````
^^ Delete the Above 😉
