### PR TITLE
Fixed Typo in Bruce Schneier's name

### DIFF
--- a/5_Privacy_Respecting_Software.md
+++ b/5_Privacy_Respecting_Software.md
@@ -117,7 +117,7 @@ corporations, governments, and hackers from logging, storing or selling your per
 
 #### Notable Mentions
 
-**[Password Safe](https://www.pwsafe.org/)** is an offline, open source password manager designed by [Bruce Schneiser](https://www.schneier.com/academic/passsafe/), with native applications for Windows, Linux, MacOS, Android and iOS, and support for YubiKey. The UI is a little dated, and there is no official browser extension, making is slightly less convenient to use compared with other options
+**[Password Safe](https://www.pwsafe.org/)** is an offline, open source password manager designed by [Bruce Schneier](https://www.schneier.com/academic/passsafe/), with native applications for Windows, Linux, MacOS, Android and iOS, and support for YubiKey. The UI is a little dated, and there is no official browser extension, making is slightly less convenient to use compared with other options
 
 **[PassBolt](https://www.passbolt.com/)** is a good option for teams. It is free, open source, self-hosted, extensible and OpenPGP based. It is specifically good for development and DevOps ussage, with integrations for the terminal, browser and chat, and can be easily extended for custom usage, and deployed quickly with Docker
 


### PR DESCRIPTION
### Category
Spelling or Grammar 

### Overview
There was a typo in Bruce Schneier's name.

### Issue Number _(if applicable)_
n/a

### Supporting Material _(if applicable)_
See Schneier's homepage: https://www.schneier.com

### Association _(if applicable)_
n/a

### Checklist

- [x] I have performed a self-review (valid markdown formatting, spelling and grammar)
- [x] I have indicated whether I have any affiliation with any software/ services added  
- [x] I agree to follow the repositories [code of conduct](/.github/CODE_OF_CONDUCT.md)
