### PR TITLE
Add Padloc to Password Managers

### DIFF
--- a/5_Privacy_Respecting_Software.md
+++ b/5_Privacy_Respecting_Software.md
@@ -114,6 +114,7 @@ corporations, governments, and hackers from logging, storing or selling your per
 **[BitWarden](https://bitwarden.com)**  | Fully-featured, open source password manager with cloud-sync. BitWarden is easy-to-use with a clean UI and client apps for desktop, web and mobile.
 **[KeePass](https://keepass.info)** | Hardened, secure and offline password manager. Does not have cloud-sync baked in, deemed to be [gold standard](https://keepass.info/ratings.html) for secure password managers. KeePass clients: [Strongbox](https://apps.apple.com/us/app/strongbox-keepass-pwsafe/id897283731) *(Mac & iOS)*, [KeePassDX](https://play.google.com/store/apps/details?id=com.kunzisoft.keepass.free) *(Android)*, [KeeWeb](https://keeweb.info) *(Web-based/ self-hosted)*, [KeePassXC](https://keepassxc.org) *(Windows, Mac & Linux)*, see more KeePass clients and extensions at [awesome-keepass](https://github.com/lgg/awesome-keepass) by @lgg. 
 **[LessPass](https://lesspass.com)** *(Self-Hosted)* | LessPass is a little different, since it generates your passwords using a hash of the website name, your username and a single master-passphrase that you reuse. It omits the need for you to ever need to store or sync your passwords. They have apps for all the common platforms and a CLI, but you can also self-host it.
+**[Padloc](https://padloc.app)** | A modern, open source password manager for individuals and teams. Beautiful, intuitive and dead simple to use. Apps available for all platforms and you can self-host it as well.
 
 #### Notable Mentions
 


### PR DESCRIPTION
This adds the open source [Padloc](https://padloc.app) Password Manager.

### Category
Software or Service Addition

### Overview
Adding a new app.

### Supporting Material
https://github.com/padloc/padloc

### Association
I'm a happy customer who has become a contributor.

### Checklist

- [x] I have performed a self-review (valid markdown formatting, spelling and grammar)
- [x] I have indicated whether I have any affiliation with any software/ services added  
- [x] I agree to follow the repositories [code of conduct](/.github/CODE_OF_CONDUCT.md)
