### PR TITLE
Remove duplicate Router IP section

### DIFF
--- a/personal-security-checklist.yml
+++ b/personal-security-checklist.yml
@@ -1065,12 +1065,6 @@
       Do not grant access to your primary WiFi network to visitors, as it enables them to interact with other
       devices on the network.
 
-  - point: Change your Router's Default IP
-    priority: Optional
-    details: >-
-      Modifying your router admin panel's default IP address will make it more difficult for malicious scripts
-      targeting local IP addresses.
-
   - point: Kill unused processes and services on your router
     priority: Optional
     details: >-


### PR DESCRIPTION
<!--
Thank you for contributing the The Personal Security Checklist 🫶
So that your PR can be reviewed quickly, please complete the following sections:
-->

#### Category
<!-- Indicate the type of PR (delete as necessary) -->
Checklist addition or deletion

#### Overview
<!-- Briefly outline your new changes -->
Removes the "Change your Router's Default IP" section of the Network page as it appears to be a duplicate of the "Change the Router’s Local IP Address" section on the same page.

#### Issue Number _(if applicable)_
<!-- If this PR is related to an issue, please include ticket number. -->
https://github.com/Lissy93/personal-security-checklist/issues/239

#### Checklist
<!-- Please complete the following checklist 😇 -->
- [x] I have performed a self-review (valid links, formatting, spelling and grammar)
- [x] I have indicated whether I have any affiliation with any software/ services edited
- [x] I have read the [Contributing Guidelines](.github/CONTRIBUTING.md), and agree to follow the [Code of Conduct](/.github/CODE_OF_CONDUCT.md)
