### PR TITLE
Add Marshall Privacy Browser to Web Browsing recommendations

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -117,6 +117,7 @@ This section outlines the steps you can take, to be better protected from threat
 
 ### Recommended Software
 - [Privacy Browsers](https://github.com/Lissy93/awesome-privacy#browsers)
+- [Marshall Privacy Browser](https://github.com/bad-antics/marshall) - Hardened WebKit2GTK browser with built-in ad blocking, fingerprint protection, and WebRTC leak prevention
 - [Browser Extensions](https://github.com/Lissy93/awesome-privacy#browser-extensions)
 - [Browser & Bookmark Sync](https://github.com/Lissy93/awesome-privacy#browser-sync)
 


### PR DESCRIPTION
Adds [Marshall](https://github.com/bad-antics/marshall) to the Recommended Software list under Web Browsing.

**Marshall** is an open-source privacy-focused browser built on WebKit2GTK with security hardening out of the box:

- 🛡️ Built-in ad and tracker blocking
- �� Canvas fingerprint protection  
- 🔒 WebRTC leak prevention (disabled by default)
- 🚫 No telemetry, analytics, or data collection
- 🐧 Native Linux support (GTK4/libadwaita)
- ⚡ Lightweight — minimal resource footprint

It fills a niche for Linux users who want a hardened browser without extensive manual configuration.

GitHub: https://github.com/bad-antics/marshall (11 ⭐)