### PR TITLE
docs: fix formatting in .github/CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,13 +5,13 @@ I would like to personally thank you for taking the time to further this list, a
 
 You can find project setup, build and deploy instructions in the [README](./README.md).
 
----
+- --
 
 > [!NOTE]
 > **Working on your first Pull Request?** You can learn more about contributing to open source at [Git-In](https://github.com/Lissy93/git-in)
 
 > [!IMPORTANT]
-> 
+>
 > - If you're updating the checklist, the only file you need to update is `personal-security-checklist.yml`. DO NOT edit the markdown or website content directly, as this will be overridden on the next build.
 > - When submitting your pull request, provide references backing up any information that you're adding/amending/removing.
 > - Please ensure you've followed our [code of conduct](/.github/CODE_OF_CONDUCT.md), that is adapted from [Contributor Covenant](https://www.contributor-covenant.org/).


### PR DESCRIPTION
## Description
removed trailing whitespace on 1 line(s); fixed 1 list item(s) missing space after marker in `.github/CONTRIBUTING.md`

These changes improve documentation consistency without altering meaning.

## Type of change
- [x] Documentation improvement
- [x] Bug fix (formatting/typo)

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] My changes follow the existing style
- [x] I have verified the changes render correctly