### PR TITLE
Add counter-OSINT guide to links

### DIFF
--- a/articles/4_Privacy_And_Security_Links.md
+++ b/articles/4_Privacy_And_Security_Links.md
@@ -597,6 +597,7 @@ This section has moved to [here](/6_Privacy_and-Security_Gadgets.md). Products, 
   - [YubiKey-Guide](https://github.com/drduh/YubiKey-Guide) by @drduh
   - [Debian-Privacy-Server-Guide](https://github.com/drduh/Debian-Privacy-Server-Guide) by @drduh
   - [personal-security-checklist](https://github.com/Lissy93/personal-security-checklist) by @lissy93
+  - [counter-osint-guide](https://github.com/soxoj/counter-osint-guide-en) by @soxoj
 - **Security Links (Hacking / Pen Testing / Threat Inteligence / CFTs)**
   - [Security_list](https://github.com/zbetcheckin/Security_list) by @zbetcheckin
   - [awesome-security](https://github.com/sbilly/awesome-security) by @sbilly


### PR DESCRIPTION
#### Category
Link

#### Overview
Adding a counter-OSINT guide to the Guides list. It covers the other side of privacy - what can be found about you from open sources, and how to reduce it. Phone numbers, emails, real names, passwords, breaches, canary tokens, plus platform-specific privacy settings for Telegram, VK and Facebook.

Sits alongside the other GitHub guides in that subsection. 365 stars, actively maintained, MIT.

#### Issue Number _(if applicable)_
N/A

#### Supporting Material _(if applicable)_
https://github.com/soxoj/counter-osint-guide-en

#### Checklist
- [x] I have performed a self-review (valid links, formatting, spelling and grammar)
- [x] I have indicated whether I have any affiliation with any software/ services edited — I am the author of the guide being added
- [x] I have disclosed if AI was used for any part of this pull request — drafted with AI assistance, reviewed and submitted by me
- [x] I have read the [Contributing Guidelines](.github/CONTRIBUTING.md), and agree to follow the [Code of Conduct](/.github/CODE_OF_CONDUCT.md)